### PR TITLE
Fix un-paramed values in request.cbDebugger

### DIFF
--- a/models/DebuggerService.cfc
+++ b/models/DebuggerService.cfc
@@ -190,32 +190,31 @@ component
 	 */
 	struct function createRequestTracker( required event ){
 		// Init the request debugger tracking
-		param request.cbDebugger = {
-			"coldbox"       : {},
-			"exception"     : {},
-			"executionTime" : 0,
-			"endFreeMemory" : 0,
-			"formData"      : serializeJSON( form ?: {} ),
-			"fullUrl"       : arguments.event.getFullUrl(),
-			"httpHost"      : cgi.HTTP_HOST,
-			"httpReferer"   : cgi.HTTP_REFERER,
-			"id"            : variables.uuid.randomUUID().toString(),
-			"inetHost"      : discoverInetHost(),
-			"ip"            : getRealIP(),
-			"localIp"       : getServerIp(),
-			"queryString"   : cgi.QUERY_STRING,
-			"requestData"   : getHTTPRequestData(
+		param request.cbDebugger = {};
+		param request.cbDebugger.coldbox       = {};
+		param request.cbDebugger.exception     = {};
+		param request.cbDebugger.executionTime = 0;
+		param request.cbDebugger.endFreeMemory = 0;
+		param request.cbDebugger.formData      = serializeJSON( form ?: {} );
+		param request.cbDebugger.fullUrl       = arguments.event.getFullUrl();
+		param request.cbDebugger.httpHost      = cgi.HTTP_HOST;
+		param request.cbDebugger.httpReferer   = cgi.HTTP_REFERER;
+		param request.cbDebugger.id            = variables.uuid.randomUUID().toString();
+		param request.cbDebugger.inetHost      = discoverInetHost();
+		param request.cbDebugger.ip            = getRealIP();
+		param request.cbDebugger.localIp       = getServerIp();
+		param request.cbDebugger.queryString   = cgi.QUERY_STRING;
+		param request.cbDebugger.requestData   = getHTTPRequestData(
 				variables.debuggerConfig.requestTracker.httpRequest.profileHTTPBody
-			),
-			"response"        : { "statusCode" : 0, "contentType" : "" },
-			"startCount"      : getTickCount(),
-			"startFreeMemory" : variables.jvmRuntime.freeMemory(),
-			"threadInfo"      : getCurrentThread().toString(),
-			"timers"          : [],
-			"timestamp"       : now(),
-			"tracers"         : [],
-			"userAgent"       : cgi.HTTP_USER_AGENT
-		};
+		);
+		param request.cbDebugger.response        = { "statusCode" : 0, "contentType" : "" };
+		param request.cbDebugger.startCount      = getTickCount();
+		param request.cbDebugger.startFreeMemory = variables.jvmRuntime.freeMemory();
+		param request.cbDebugger.threadInfo      = getCurrentThread().toString();
+		param request.cbDebugger.timers          = [];
+		param request.cbDebugger.timestamp       = now();
+		param request.cbDebugger.tracers         = [];
+		param request.cbDebugger.userAgent       = cgi.HTTP_USER_AGENT;
 
 		// Event before recording
 		variables.interceptorService.announce(


### PR DESCRIPTION
# Description

If `request.cbDebugger` is already an empty struct, then none of these required keys will be created.

Resolves this error obtained on startup:

![Screenshot from 2023-12-21 14-59-18](https://github.com/michaelborn/cbdebugger/assets/8106227/a9c4f2cb-2ddd-4262-8750-b9330d224b1e)

## Issues

All PRs must have an accompanied issue. Please make sure you created it and linked it here.

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
